### PR TITLE
Add alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Please add your owner info in data.yaml:
   gitee_id: 'the gitee id'
   github_id: 'the github id'
   gitlab_id: 'the gitlab id'
+  # alias is used to discover your commits (name/gitee_id/github_id/gitlab_id is in default alias names) 
+  alias:
+  - "Your alias name"
+  - "Other alias name you want to track"
   # Required, The repo url list you contributed. Only the default branch would be counted.
   repos:
   - https://github.com/opensourceways/whitebox

--- a/data.yml
+++ b/data.yml
@@ -2,6 +2,8 @@ users:
 - name: 'Yikun Jiang'
   gitee_id: 'yikunkero'
   github_id: 'Yikun'
+  alias:
+  - "Jiang Yikun"
   # Recommended, only fetch the default branch of repos
   repos:
   - https://github.com/Yikun/hub-mirror-action

--- a/data.yml
+++ b/data.yml
@@ -2,8 +2,6 @@ users:
 - name: 'Yikun Jiang'
   gitee_id: 'yikunkero'
   github_id: 'Yikun'
-  alias:
-  - "Jiang Yikun"
   # Recommended, only fetch the default branch of repos
   repos:
   - https://github.com/Yikun/hub-mirror-action
@@ -430,6 +428,8 @@ users:
 - name: 'Peng Lei'
   gitee_id: 'PYinuo'
   github_id: 'Peng-Lei'
+  alias:
+  - "PengLei"
   # Recommended, only fetch the default branch of repos
   repos:
   # Optional, fetch all branches of repos

--- a/tools/import.py
+++ b/tools/import.py
@@ -48,11 +48,12 @@ def generate_users():
         x = yaml.load(f, Loader=yaml.FullLoader)
         users = x.get("users")
         for user in users:
+            name = user.get('name', '')
             gitee_id = user.get('gitee_id', '')
             github_id = user.get('github_id', '')
             gitlab_id = user.get('gitlab_id', '')
             alias = [x for x in user.get('alias', [])]
-            alias += [gitee_id, github_id, gitlab_id]
+            alias += [gitee_id, github_id, gitlab_id, name]
             names = set(x for x in alias if x)
             for name in names:
                 doc = {

--- a/tools/import.py
+++ b/tools/import.py
@@ -57,7 +57,8 @@ def generate_users():
             for name in names:
                 doc = {
                     "name": user.get('name'),
-                    "alias": name
+                    "alias": name,
+                    "created_at": time.strftime("%Y-%m-%dT%H:00:00+0800")
                 }
                 yield doc
 


### PR DESCRIPTION
This patch adds the alias support for users.

By default, the gitee/github/gitlab id and name would be your specifc alias, if you have any other alias name which is configured in git config (`user.name`), you need to append in `name.alias`.