### PR TITLE
Add alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Please add your owner info in data.yaml:
   gitee_id: 'the gitee id'
   github_id: 'the github id'
   gitlab_id: 'the gitlab id'
+  # alias is used to discover your commits (name/gitee_id/github_id/gitlab_id is in default alias names) 
   alias:
   - "Your alias name"
-  - "other alias name"
+  - "Other alias name you want to track"
   # Required, The repo url list you contributed. Only the default branch would be counted.
   repos:
   - https://github.com/opensourceways/whitebox

--- a/data.yml
+++ b/data.yml
@@ -428,6 +428,8 @@ users:
 - name: 'Peng Lei'
   gitee_id: 'PYinuo'
   github_id: 'Peng-Lei'
+  alias:
+  - "PengLei"
   # Recommended, only fetch the default branch of repos
   repos:
   # Optional, fetch all branches of repos

--- a/tools/import.py
+++ b/tools/import.py
@@ -43,6 +43,26 @@ def generate_projects():
                 yield doc
 
 
+def generate_users():
+    with open("./data.yml") as f:
+        x = yaml.load(f, Loader=yaml.FullLoader)
+        users = x.get("users")
+        for user in users:
+            name = user.get('name', '')
+            gitee_id = user.get('gitee_id', '')
+            github_id = user.get('github_id', '')
+            gitlab_id = user.get('gitlab_id', '')
+            alias = [x for x in user.get('alias', [])]
+            alias += [gitee_id, github_id, gitlab_id, name]
+            names = set(x for x in alias if x)
+            for name in names:
+                doc = {
+                    "name": user.get('name'),
+                    "alias": name,
+                    "created_at": time.strftime("%Y-%m-%dT%H:00:00+0800")
+                }
+                yield doc
+
 @click.command()
 @click.option('--host', help='The public IP of ES cluster.')
 @click.option('--user', help='The user name of ES cluster.')
@@ -52,23 +72,30 @@ def _main(host, user, passwd, mode):
     if mode == "check":
         for proj in generate_projects():
             print(proj.get("name"), proj.get("user"), proj.get("repo"))
+        for name in generate_users():
+            print(name.get("name"), name.get("alias"))
     elif mode == "import":
         _import(host, user, passwd)
     else:
         print("Unknow mode, only support 'check' and 'import'.")
 
 
-def _import(host, user, passwd):
-    es = Elasticsearch([host], http_auth=(user, passwd), use_ssl=True, verify_certs=False)
-    # Cleanup es index
-    es.indices.delete(index='whitebox_projects', ignore=[404])
-
+def _bulk(es, index, iter):
+    es.indices.delete(index=index, ignore=[404])
     actions = streaming_bulk(
-        client=es, index="whitebox_projects", actions=generate_projects()
+        client=es, index=index, actions=iter
     )
     for ok, action in actions:
         if not ok:
             print("Failed to insert doc...")
+
+
+def _import(host, user, passwd):
+    es = Elasticsearch([host], http_auth=(user, passwd), use_ssl=True, verify_certs=False)
+
+    _bulk(es, 'whitebox_projects', generate_projects())
+    _bulk(es, 'whitebox_users', generate_users())
+
     print("Load complete.")
 
 


### PR DESCRIPTION
This patch adds the alias support for users.

By default, the gitee/github/gitlab id and name would be your specifc alias, if you have any other alias name which is configured in git config (user.name), you need to append in name.alias.